### PR TITLE
Add format output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,33 @@ Generate epub from http://www.linovel.com/
 
 ![lknovel截图][image-2]
 
+## Generate format other than epub
+This feature require Calibre, a ebook managing software, installed and only works on Mac OS X for now. To use it, just add `--format` argument followed with a space and the format you wish to output.
+
+For example:
+`python linovel.py http://www.linovel.com/n/vollist/2130.html --format mobi`
+
+Available output formats:
+* AZW3
+* EPUB
+* FB2
+* HTML
+* HTMLZ
+* LIT
+* LRF
+* MOBI
+* OEB
+* PDB
+* PDF
+* PML
+* RB
+* RTF
+* SNB
+* TCR
+* TXT
+* TXTZ
+
+
 The previous repo is [lknovel][6]
 
 [![Bitdeli Badge][image-3]][7]

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Generate epub from http://www.linovel.com/
 
 	Usage:
 	    linovel.py
-	    linovel.py [-s] [-o | --output=<output_dir>] [-c | --cover=<cover_path>] <url>...
-	    linovel.py <url>... [-s] [-o | --output=<output_dir>] [-c | --cover=<cover_path>]
+	    linovel.py [-s] [-o | --output=<output_dir>] [-c | --cover=<cover_path>] [--format=<out_format>] <url>...
+	    linovel.py <url>... [-s] [-o | --output=<output_dir>] [-c | --cover=<cover_path>] [--format=<out_format>]
 	    linovel.py -h | --help
 	    linovel.py -v | --version
 	
@@ -31,12 +31,13 @@ Generate epub from http://www.linovel.com/
 	    -s                                         Single thread
 	    -o=<output_dir> --output=<output_dir>      Output folder
 	    -c=<cover_path> --cover=<cover_path>       Cover path
+	    --format=<out_format>                      Output format
 	    -h --help                                  Show this screen
 	    -v --version                               Show version
 	
 	Examples:
-	    linovel.py -s http://www.linovel.com/n/vollist/492.html
-	    linovel.py -o d:/ http://www.linovel.com/n/book/1578.html
+	    linovel.py http://www.linovel.com/n/vollist/492.html -s
+	    linovel.py http://www.linovel.com/n/book/1578.html -o d:/
 
 ![lknovel截图][image-2]
 

--- a/epub.py
+++ b/epub.py
@@ -7,6 +7,7 @@ import queue
 import shutil
 import uuid
 import zipfile
+from subprocess import call
 
 from bs4 import BeautifulSoup
 import requests
@@ -35,13 +36,15 @@ class Epub:
         chapter: A list represent the chapter
         base_path: A string represent the epub temp path
         date: A string represent the date the book last updated (As specified in ISO 8601)
+        out_format: A string represent the output format (Epub by default) (For other format Mac OS X only)
 
     """
 
-    def __init__(self, output_dir=None, cover_path=None, single_thread=False, **kwargs):
+    def __init__(self, output_dir=None, cover_path=None, single_thread=False, out_format='epub', **kwargs):
         self.output_dir = output_dir
         self.cover_path = cover_path
         self.single_thread = single_thread
+        self.out_format = out_format
 
         self.uuid = str(uuid.uuid1())
 
@@ -298,6 +301,14 @@ class Epub:
             shutil.move(folder_name + '.epub', self.output_dir)
             print('已生成', folder_name + '.epub')
 
+    def convert(self, out_format='mobi'):
+        file_in = self.book_name + '.epub'
+        file_out = self.book_name + '.' + out_format
+        command = ['/Applications/calibre.app/Contents/MacOS/ebook-convert', file_in, file_out]
+        call(command)
+        os.remove(file_in)
+
+
     def generate_epub(self):
         """generate epub file from novel"""
         folder_name = re.sub(r'[<>:"/\\|\?\*]', '_', self.book_name)
@@ -308,7 +319,9 @@ class Epub:
         self.create_html()
 
         self.zip_files()
-        self.print_info('\n已生成：' + self.book_name + '.epub\n')
+        if self.out_format != 'epub':
+            self.convert()
+        self.print_info('\n已生成：' + self.book_name + '.' + self.out_format + '\n')
 
         # delete temp file
         shutil.rmtree(self.base_path)

--- a/linovel.py
+++ b/linovel.py
@@ -3,8 +3,8 @@
 
 Usage:
     linovel.py
-    linovel.py [-s] [-o | --output=<output_dir>] [-c | --cover=<cover_path>] <url>...
-    linovel.py <url>... [-s] [-o | --output=<output_dir>] [-c | --cover=<cover_path>]
+    linovel.py [-s] [-o | --output=<output_dir>] [-c | --cover=<cover_path>] [--format=<out_format>] <url>...
+    linovel.py <url>... [-s] [-o | --output=<output_dir>] [-c | --cover=<cover_path>] [--format=<out_format>]
     linovel.py -h | --help
     linovel.py -v | --version
 
@@ -15,6 +15,7 @@ Options:
     -s                                         Single thread
     -o=<output_dir> --output=<output_dir>      Output folder
     -c=<cover_path> --cover=<cover_path>       Cover path
+    --format=<out_format>                      Output format
     -h --help                                  Show this screen
     -v --version                               Show version
 
@@ -63,7 +64,7 @@ def check_url(url):
         return False
 
 
-def grab_volume(url, output_dir, cover_path):
+def grab_volume(url, output_dir, cover_path, out_format):
     """
     grab volume
     
@@ -71,12 +72,13 @@ def grab_volume(url, output_dir, cover_path):
         url: A string represent the url which was input by user
         output_dir: A string represent the path of the output EPUB file
         cover_file: A string represent the path of the EPUB cover
+        out_format: A string represent the output format
     """
     try:
         print('Getting:' + url)
         novel = Novel(url=url, single_thread=_SINGLE_THREAD)
         novel.get_novel_information()
-        epub = Epub(output_dir=output_dir, cover_path=cover_path, **novel.novel_information())
+        epub = Epub(output_dir=output_dir, cover_path=cover_path, out_format=out_format, **novel.novel_information())
         epub.generate_epub()
 
     except Exception as e:
@@ -99,7 +101,7 @@ def parse_page(url):
     return BeautifulSoup(r.text, 'lxml')
 
 
-def grab_booklist(url, output_dir, cover_path):
+def grab_booklist(url, output_dir, cover_path, out_format):
     """
     grab each volume in the booklist
 
@@ -112,10 +114,10 @@ def grab_booklist(url, output_dir, cover_path):
     volume_links = soup.select('li.linovel-book-item h3 a')
     for volume in volume_links:
         volume_link = 'http://www.linovel.com' + volume['href']
-        grab_volume(volume_link, output_dir, cover_path)
+        grab_volume(volume_link, output_dir, cover_path, out_format)
 
 
-def start(urls, output_dir=None, cover_path=None):
+def start(urls, output_dir=None, cover_path=None, out_format=None):
     """
     start the job using url
 
@@ -127,9 +129,9 @@ def start(urls, output_dir=None, cover_path=None):
     for url in urls:
         check_result = check_url(url)
         if check_result == 'book':
-            grab_volume(url, output_dir, cover_path)
+            grab_volume(url, output_dir, cover_path, out_format)
         elif check_result == 'vollist':
-            grab_booklist(url, output_dir, cover_path)
+            grab_booklist(url, output_dir, cover_path, out_format)
         else:
             print('请输入正确的网址，例如：\nhttp://www.linovel.com/n/vollist/492.html'
                   '\nhttp://www.linovel.com/n/book/1578.html')
@@ -142,14 +144,16 @@ def main():
         _SINGLE_THREAD = arguments['-s']
         output_dir = None if not arguments['--output'] else arguments['--output'][0]
         cover_path = None if not arguments['--cover'] else arguments['--cover'][0]
+        out_format = 'epub' if not arguments['--format'] else arguments['--format']
     else:
         urls = input('Please input urls（separate with space）:').split()
         if is_single_thread():
             _SINGLE_THREAD = True
         output_dir = None
         cover_path = None
+        out_format = None
     if urls:
-        start(urls, output_dir, cover_path)
+        start(urls, output_dir, cover_path, out_format)
     else:
         raise RuntimeError('No url')
 


### PR DESCRIPTION
Add format output option by using Calibre command line tool. This feature only works with Mac OS X and require Calibre installed.
