### PR TITLE
Fix: image url request throw too many exceptions.

### DIFF
--- a/epub.py
+++ b/epub.py
@@ -94,6 +94,7 @@ class Epub:
         download pictures from _download_queue
         change headers if timeout
         """
+        error_counter = {}
         while not _download_queue.empty():
             url = _download_queue.get()
             try:
@@ -109,7 +110,13 @@ class Epub:
                 self.download_progress()
             except Exception as e:
                 print(e)
-                _download_queue.put(url)
+                error_count = error_counter.get(url, 0)
+                if error_count < 5:
+                    error_counter[url] = error_count + 1
+                    _download_queue.put(url)
+                else:
+                    print('Too many error, cancel.')
+                    self.download_progress()
             finally:
                 _download_queue.task_done()
 


### PR DESCRIPTION
This is a workaround.

Try this book to check: http://www.wenku8.com/book/173.htm

Without this fix, the download progress will be halted on vol.3 forever.

# Example

```sh
$ python3 linovel.py http://www.wenku8.com/book/173.htm

...

Generating 渎神之主 第三卷 压抑 The oppression
Start downloading pictures, total number:22
19/22[####################################################        ]HTTPConnectionPool(host='adc.yupoo.com', port=80): Max retries exceeded with url: /704.gif (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.HTTPConnection object at 0x7f38bcb69f28>, 'Connection to adc.yupoo.com timed out. (connect timeout=10)'))
21/22[#########################################################   ]HTTPConnectionPool(host='adc.yupoo.com', port=80): Max retries exceeded with url: /704.gif (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.HTTPConnection object at 0x7f38bd1408d0>, 'Connection to adc.yupoo.com timed out. (connect timeout=10)'))
HTTPConnectionPool(host='adc.yupoo.com', port=80): Max retries exceeded with url: /704.gif (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.HTTPConnection object at 0x7f38bcbb7d68>, 'Connection to adc.yupoo.com timed out. (connect timeout=10)'))
HTTPConnectionPool(host='adc.yupoo.com', port=80): Max retries exceeded with url: /704.gif (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.HTTPConnection object at 0x7f38bd133940>, 'Connection to adc.yupoo.com timed out. (connect timeout=10)'))
HTTPConnectionPool(host='adc.yupoo.com', port=80): Max retries exceeded with url: /704.gif (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.HTTPConnection object at 0x7f38bd1316a0>, 'Connection to adc.yupoo.com timed out. (connect timeout=10)'))
HTTPConnectionPool(host='adc.yupoo.com', port=80): Max retries exceeded with url: /704.gif (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.HTTPConnection object at 0x7f38bcbafbe0>, 'Connection to adc.yupoo.com timed out. (connect timeout=10)'))
Too many error, cancel.
22/22[############################################################]


已生成：渎神之主 第三卷 压抑 The oppression.epub

...
```