### PR TITLE
bug fix: 匹配全部文库

### DIFF
--- a/novel_360dxs.py
+++ b/novel_360dxs.py
@@ -22,7 +22,7 @@ class Dxs(AbstractNovel):
 
     @staticmethod
     def check_url(url):
-        url_checker = re.compile(r'http://qitawenku.360dxs.com/book_(\d+).html')
+        url_checker = re.compile(r'http://(\S+).360dxs.com/book_(\d+).html')
         return True if url_checker.search(url) else False
 
     @staticmethod


### PR DESCRIPTION
re.compile(r'http://qitawenku.360dxs.com/book_(\d+).html') -> re.compile(r'http://(\S+).360dxs.com/book_(\d+).html')