### PR TITLE
简单修复360dxs中，若只有一卷无法下载bug

### DIFF
--- a/novel_360dxs.py
+++ b/novel_360dxs.py
@@ -143,10 +143,9 @@ class Dxs(AbstractNovel):
         self.extract_common_information(soup)
         if volumes[1:-2]:
             for volume in volumes[1:-2]:
-                print(volume)
+                self.parse_book(volume))
         else:
             for volume in volumes[1:-1]:
-                print(volume)
                 self.parse_book(volume)
     def extract_novel_information(self):
         """extract novel information"""

--- a/novel_360dxs.py
+++ b/novel_360dxs.py
@@ -141,9 +141,14 @@ class Dxs(AbstractNovel):
         soup = self.parse_page(self.url)
         volumes = soup.select('div.am-panel-bd.book-info')
         self.extract_common_information(soup)
-        for volume in volumes[1:-2]:
-            self.parse_book(volume)
-
+        print(volumes[1:-2])
+        if volumes[1:-2]:
+            for volume in volumes[1:-2]:
+                print(volume)
+        else:
+            for volume in volumes[1:-1]:
+                print(volume)
+                self.parse_book(volume)
     def extract_novel_information(self):
         """extract novel information"""
         self.parse_vollist()

--- a/novel_360dxs.py
+++ b/novel_360dxs.py
@@ -141,7 +141,6 @@ class Dxs(AbstractNovel):
         soup = self.parse_page(self.url)
         volumes = soup.select('div.am-panel-bd.book-info')
         self.extract_common_information(soup)
-        print(volumes[1:-2])
         if volumes[1:-2]:
             for volume in volumes[1:-2]:
                 print(volume)


### PR DESCRIPTION
如果在360dxs网站上，一本书只有一卷的话，会无法找到文本数据的问题